### PR TITLE
README was incorrect with instructions on how to use the gem:

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,15 @@ provides a UserAgent.driver method to return a new web-driver with user agent an
 
 	require 'selenium-webdriver'
 	require 'webdriver-user-agent'
-	driver = WebDriver::UserAgent.driver(:browser => :chrome, :agent => :iphone, :orientation => :landscape)
+	driver = Webdriver::UserAgent.driver(:browser => :chrome, :agent => :iphone, :orientation => :landscape)
 	driver.get 'http://tiffany.com'
 	driver.current_url.should == 'http://m.tiffany.com/International.aspx'
 
 ### Example using random user agent
 
-	require 'selenium-webdriber'
+	require 'selenium-webdriver'
 	require 'webdriver-user-agent'
-	driver = WebDriver::UserAgent.driver(:agent => :random)
+	driver = Webdriver::UserAgent.driver(:agent => :random)
 	driver.execute_script('return navigator.userAgent')
 	# random agent like "Mozilla/5.0 (Windows; U; Windows NT 5.0; en-US; rv:0.9.2) Gecko/20010726 Netscape6/6.1"
 
@@ -55,8 +55,8 @@ provides a UserAgent.driver method to return a new web-driver with user agent an
 
 	require 'watir-webdriver'
 	require 'webdriver-user-agent'
-	driver = UserAgent.driver(:browser => :chrome, :agent => :iphone, :orientation => :landscape)
-	browser = Watir::Browser.new driver
+	driver = Webdriver::UserAgent.driver(:browser => :chrome, :agent => :iphone, :orientation => :landscape)
+	browser = Watir::Browser.new(driver)
 	browser.goto 'tiffany.com'
 	browser.url.should == 'http://m.tiffany.com/International.aspx'
 


### PR DESCRIPTION
- the first two examples referenced an incorrect module name (WebDriver
  instead of webdriver)
- the watir webdriver example did not include a reference to the
  Webdriver module causing a "NameError: uninitialized constant
  UserAgent" error to be thrown when following the documentation
